### PR TITLE
Add ClawBench browser-agent benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Fresh 2026 work that is already drawing attention.
 *Corresponds to §2 (Background) and the running examples throughout.*
 
 <details>
-<summary><b>Show 37 papers</b></summary>
+<summary><b>Show 38 papers</b></summary>
 
 - **[Auto-GPT for Online Decision Making: Benchmarks and Additional Opinions](https://arxiv.org/abs/2306.02224)** (Yang et al., arXiv 2023) - *Only peer-reviewed-adjacent empirical study of the widely-influential (but paper-less) AutoGPT autonomous-agent design pattern.* [[code](https://github.com/younghuman/LLMAgent)]
 - **[AgentBench: Evaluating LLMs as Agents](https://arxiv.org/abs/2308.03688)** (Liu et al., ICLR 2024) - *The standard reference benchmark for measuring general single-agent capability across heterogeneous environments.* ⭐ [[code](https://github.com/THUDM/AgentBench)]
@@ -565,6 +565,7 @@ Fresh 2026 work that is already drawing attention.
 - **[Agent-as-a-Judge: Evaluate Agents with Agents](https://arxiv.org/abs/2410.10934)** (Zhuge et al., arXiv 2024) - *Systematizes agentic evaluation of agents; the reference point for judge-circularity concerns.* [[code](https://github.com/metauto-ai/agent-as-a-judge)]
 - **[Holistic Agent Leaderboard: The Missing Infrastructure for AI Agent Evaluation](https://arxiv.org/abs/2510.11977)** (Kapoor et al., arXiv 2025) - *Standardized harness that re-evaluates agents at scale with cost reported alongside accuracy.*
 - **[Terminal-Bench: Benchmarking Agents on Hard, Realistic Tasks in Command Line Interfaces](https://arxiv.org/abs/2601.11868)** (Merrill et al., arXiv 2026) - *Hard, realistic command-line tasks; a de facto standard for terminal agents.* [[code](https://github.com/laude-institute/terminal-bench)]
+- **[ClawBench: Can AI Agents Complete Everyday Online Tasks?](https://arxiv.org/abs/2604.08523)** (Zhang et al., arXiv 2026) - *A browser-agent benchmark of 153 everyday online tasks across 144 production websites and 15 categories, with intercepted final submissions for safe evaluation.* [[code](https://github.com/TIGER-AI-Lab/ClawBench)] [[project](https://claw-bench.com)]
 
 - **[Can AI Agents Answer Your Data Questions? A Benchmark for Data Agents (DataAgentBench)](https://arxiv.org/abs/2603.20576)** (Ma et al., arXiv 2026) - *Benchmark across heterogeneous database systems; frontier models reach only 38% accuracy on complex data questions.* [[code](https://github.com/ucbepic/DataAgentBench)]
 - **[AgencyBench: Benchmarking the Frontiers of Autonomous Agents in 1M-Token Real-World Contexts](https://arxiv.org/abs/2601.11044)** (Li et al., arXiv 2026) - *32 real-world long-horizon scenarios testing autonomous agents under up to 1M-token contexts.* [[code](https://github.com/GAIR-NLP/AgencyBench)]


### PR DESCRIPTION
ClawBench is a directly relevant benchmark for this LLM-agent paper list.

- Adds the arXiv paper and official code repository
- Describes its 153 everyday online tasks across 144 production websites and 15 categories
- Notes intercepted final submissions for safe evaluation

Links: https://arxiv.org/abs/2604.08523 and https://github.com/TIGER-AI-Lab/ClawBench

Please feel free to adjust wording or placement.